### PR TITLE
add condtion to echo wallets only for dev-1 to dev-5

### DIFF
--- a/run-system-tests/action.yml
+++ b/run-system-tests/action.yml
@@ -211,8 +211,11 @@ runs:
         exit_code=0
 
         echo '::echo::off'
-        echo "$SMART_CONTRACT_OWNER_WALLET_JSON" >> ./config/sc_owner_wallet.json
-        echo '{"client_id": "591d6d0d5642bdbc924756ca2647b4b59adce0acd02a487ecc4d1bd4669293a8","client_key": "ac8798bcadd5ce5ea14f4745850eec61aa080e6fedc1d769af95c42e0079ba03ee9710e9dc966f7c5eb9cd6ef9184af51869d5a345b9520e507aa55ba22bf902","keys": [{"public_key": "ac8798bcadd5ce5ea14f4745850eec61aa080e6fedc1d769af95c42e0079ba03ee9710e9dc966f7c5eb9cd6ef9184af51869d5a345b9520e507aa55ba22bf902","private_key": "fbdc0bcc12168588e2def826b7ee9d8b4c6f1fbacf22ee5064b7db49482b8f0d"}],"mnemonics": "economy day fan flower between rebuild valid bid catch bargain vivid hybrid room permit check manage mean twelve damage summer close churn boat either","version": "1.0","date_created": "2021-12-04T17:03:37Z"}' >> ./config/blobber_owner_wallet.json
+         if [[ "${{ env.NETWORK_URL }}" == "dev-3.devnet-0chain.net" || "${{ env.NETWORK_URL }}" == "dev-4.devnet-0chain.net" || "${{ env.NETWORK_URL }}" == "dev-5.devnet-0chain.net" || "${{ env.NETWORK_URL }}" == "dev-1.devnet-0chain.net" || "${{ env.NETWORK_URL }}" == "dev-2.devnet-0chain.net" ]];
+          then
+            echo "$SMART_CONTRACT_OWNER_WALLET_JSON" >> ./config/sc_owner_wallet.json
+            echo '{"client_id": "591d6d0d5642bdbc924756ca2647b4b59adce0acd02a487ecc4d1bd4669293a8","client_key": "ac8798bcadd5ce5ea14f4745850eec61aa080e6fedc1d769af95c42e0079ba03ee9710e9dc966f7c5eb9cd6ef9184af51869d5a345b9520e507aa55ba22bf902","keys": [{"public_key": "ac8798bcadd5ce5ea14f4745850eec61aa080e6fedc1d769af95c42e0079ba03ee9710e9dc966f7c5eb9cd6ef9184af51869d5a345b9520e507aa55ba22bf902","private_key": "fbdc0bcc12168588e2def826b7ee9d8b4c6f1fbacf22ee5064b7db49482b8f0d"}],"mnemonics": "economy day fan flower between rebuild valid bid catch bargain vivid hybrid room permit check manage mean twelve damage summer close churn boat either","version": "1.0","date_created": "2021-12-04T17:03:37Z"}' >> ./config/blobber_owner_wallet.json
+        fi
 
         if [[ "${{ env.NETWORK_URL }}" == "dev-3.devnet-0chain.net" ]];
          then


### PR DESCRIPTION
Skipping config/settings update in case of missing delegate wallet is already in place in system_test. This PR stops actions from writing owner/delegate wallets  outside dev-[1:5] networks so those tests can be skipped and don't block devs.

![image](https://user-images.githubusercontent.com/42718091/155007692-8c92046c-075d-4ed8-b86e-4fa6cbd1abf7.png)
