### PR TITLE
Update gosdk for blobber stake 

### DIFF
--- a/.github/workflows/manual_system_tests.yml
+++ b/.github/workflows/manual_system_tests.yml
@@ -38,12 +38,12 @@ on:
          description: 'miner branch which the tests will use'
          default: 'staging'
          required: false
-         type: string  
+         type: string
        sharder_branch:
          description: 'sharder branch which the tests will use'
          default: 'staging'
          required: false
-         type: string   
+         type: string
        zbox_cli_branch:
         description: '0Box CLI branch which the tests will use'
         default: 'staging'
@@ -256,7 +256,7 @@ jobs:
         explorer_image: ${{ env.EXPLORER_TAG }}
         zproxy_image: ${{ env.ZPROXY_TAG }}
         zsearch_image: ${{ env.ZSEARCH_TAG }}
-        blobber_stake_image: latest
+        blobber_stake_image: "state-changes-count-block"
 
     - name: "Run System tests"
       if: ${{ inputs.skip_tests == 'FALSE' }}

--- a/deploy-0chain/action.yml
+++ b/deploy-0chain/action.yml
@@ -50,7 +50,7 @@ inputs:
     required: false
   blobber_stake_image:
     description: 'Blobber stake DOCKER IMAGE to deploy'
-    default: 'latest'
+    default: 'state-changes-count-block'
     required: false
   teardown_condition:
     description: 'Variable on which to teardown network'


### PR DESCRIPTION
Update gosdk for blobber stake to support `state_changes_count` for block.