### PR TITLE
Replace ./zwallet getblobbers with ./zbox ls-blobber --all

### DIFF
--- a/deploy-0chain/action.yml
+++ b/deploy-0chain/action.yml
@@ -353,7 +353,7 @@ runs:
         count=0
         while [[ $count -le 5 ]]
         do
-          retry ./zwallet getblobbers --all --silent --configDir . --config ./zbox_config.yaml --wallet ../ignore | grep -o "[a-z0-9]\{64\}" > build.log
+          retry ./zbox ls-blobbers --all --silent --configDir . --config ./zbox_config.yaml --wallet ../ignore | grep -o "[a-z0-9]\{64\}" > build.log
           num=$(cat build.log | wc -l)
 
           echo "Stake [$count] output:"

--- a/deploy-0chain/action.yml
+++ b/deploy-0chain/action.yml
@@ -353,7 +353,7 @@ runs:
         count=0
         while [[ $count -le 5 ]]
         do
-          retry ./zwallet getblobbers --silent --configDir . --config ./zbox_config.yaml --wallet ../ignore | grep -o "[a-z0-9]\{64\}" > build.log
+          retry ./zwallet getblobbers --all --silent --configDir . --config ./zbox_config.yaml --wallet ../ignore | grep -o "[a-z0-9]\{64\}" > build.log
           num=$(cat build.log | wc -l)
 
           echo "Stake [$count] output:"


### PR DESCRIPTION
Replace ./zwallet getblobbers with ./zbox ls-blobber --all.

This ensures one of the blobbers is not missing due to healthcheck issue.