### PR TITLE
Feature/add long running test suite

### DIFF
--- a/run-system-tests/action.yml
+++ b/run-system-tests/action.yml
@@ -46,6 +46,14 @@ inputs:
     required: false
     default: "true"
     description: 'Enable or disable CLI system tests'
+  run_api_system_tests:
+    required: false
+    default: "true"
+    description: 'Enable or disable API system tests'
+  run_tokenomics_system_tests:
+    required: false
+    default: "false"
+    description: 'Enable or disable tokenomics system tests'
   TENDERLY_FORK_ID:
     required: true
     description: 'Tenderly fork ID is used to use Tenderly fork simulations for bridge tests'
@@ -73,15 +81,17 @@ runs:
         echo "RUNNING SYSTEM TESTS WITH THE FOLLOWING CONFIGURATION:"
         echo "======================================================"
         echo
-        echo "System tests branch:    [${{ env.SYSTEM_TESTS_BRANCH }}]"
-        echo "0Chain network URL:     [${{ env.NETWORK_URL }}]"
-        echo "0box network URL:       [0box.${{ env.NETWORK_URL }}]"
-        echo "0box CLI branch:        [${{ env.ZBOX_BRANCH }}]"
-        echo "0wallet CLI branch:     [${{ env.ZWALLET_BRANCH }}]"
-        echo "Ethereum node URL:      [https://rpc.tenderly.co/fork/${{ inputs.TENDERLY_FORK_ID }}]"
-        echo "Custom gosdk version:   [${{ inputs.custom_go_sdk_version }}]"
-        echo "Test file filter:       [${{ inputs.test_file_filter }}]"
-        echo "Running CLI tests:      [${{ inputs.run_cli_system_tests }}]"
+        echo "System tests branch:      [${{ env.SYSTEM_TESTS_BRANCH }}]"
+        echo "0Chain network URL:       [${{ env.NETWORK_URL }}]"
+        echo "0box network URL:         [0box.${{ env.NETWORK_URL }}]"
+        echo "0box CLI branch:          [${{ env.ZBOX_BRANCH }}]"
+        echo "0wallet CLI branch:       [${{ env.ZWALLET_BRANCH }}]"
+        echo "Ethereum node URL:        [https://rpc.tenderly.co/fork/${{ inputs.TENDERLY_FORK_ID }}]"
+        echo "Custom gosdk version:     [${{ inputs.custom_go_sdk_version }}]"
+        echo "Test file filter:         [${{ inputs.test_file_filter }}]"
+        echo "Running CLI tests:        [${{ inputs.run_cli_system_tests }}]"
+        echo "Running API tests:        [${{ inputs.run_api_system_tests }}]"
+        echo "Running Tokenomics tests: [${{ inputs.run_tokenomics_system_tests }}]"
 
     - name: "Checkout System Tests"
       uses: actions/checkout@v3
@@ -175,6 +185,13 @@ runs:
               echo RUN_CLI_SYSTEM_TESTS=true >> $GITHUB_ENV
         fi
         
+        if [ "${{ inputs.run_api_system_tests }}" == "false" ];
+           then
+              echo RUN_API_SYSTEM_TESTS=false >> $GITHUB_ENV
+          else
+              echo RUN_API_SYSTEM_TESTS=true >> $GITHUB_ENV
+        fi
+        
         if [ "${{ inputs.retry_failures }}" == "true" ];
            then
               echo SHOULD_RETRY_FAILURES='--rerun-fails --rerun-fails-max-failures=25' >> $GITHUB_ENV
@@ -187,6 +204,13 @@ runs:
               echo RUN_SUBSET_OF_TESTS=false >> $GITHUB_ENV
            else
               echo RUN_SUBSET_OF_TESTS=true >> $GITHUB_ENV
+        fi
+        
+         if [ "${{ inputs.run_tokenomics_system_tests }}" == "false" ];
+           then
+              echo RUN_TOKENOMICS_SYSTEM_TESTS=false >> $GITHUB_ENV
+          else
+              echo RUN_TOKENOMICS_SYSTEM_TESTS=true >> $GITHUB_ENV
         fi
 
         BRANCH_DIR=$(echo $([ -z '${{ github.event.pull_request.head.sha }}' ] && echo ${GITHUB_REF#refs/*/} || echo $GITHUB_HEAD_REF) |  sed 's/\//_/g')
@@ -211,14 +235,17 @@ runs:
 
         printf '#!/bin/bash\nset -o pipefail\n[ -z "$1" ] && TESTS_TO_RUN="-run  ^Test[^___]*$ ./..." || TESTS_TO_RUN=$1\nCONFIG_PATH=./config/api_tests_config.yaml go test -timeout=20m $TESTS_TO_RUN -json -count=1 | sed -r "/(=== (CONT|RUN|PAUSE).*)|(--- FAIL:.*)|(\\"Test\\":\\".*\/[pP]arallel\\")/d"' > API_TEST_RUNNER_COMMAND.sh && chmod 777 API_TEST_RUNNER_COMMAND.sh
         printf '#!/bin/bash\nset -o pipefail\n[ -z "$1" ] && TESTS_TO_RUN="-run  ^Test[^___]*$ ./..." || TESTS_TO_RUN=$1\nCONFIG_PATH=./zbox_config.yaml go test -timeout=120m $TESTS_TO_RUN -json -count=1 | sed -r "/(=== (CONT|RUN|PAUSE).*)|(--- FAIL:.*)|(\\"Test\\":\\".*\/[pP]arallel\\")/d"' > TEST_RUNNER_COMMAND.sh && chmod 777 TEST_RUNNER_COMMAND.sh
+        printf '#!/bin/bash\nset -o pipefail\n[ -z "$1" ] && TESTS_TO_RUN="-run  ^Test[^___]*$ ./..." || TESTS_TO_RUN=$1\nCONFIG_PATH=./config/tokenomics_tests_config.yaml go test -timeout=120m $TESTS_TO_RUN -json -count=1 | sed -r "/(=== (CONT|RUN|PAUSE).*)|(--- FAIL:.*)|(\\"Test\\":\\".*\/[pP]arallel\\")/d"' > TOKENOMICS_TEST_RUNNER_COMMAND.sh && chmod 777 TOKENOMICS_TEST_RUNNER_COMMAND.sh
         printf '#!/bin/bash\nset -o pipefail\nCONFIG_PATH=./zbox_config.yaml go test -timeout=60m -run  "^Test___Flaky.*$" ./... -json -count=1 | sed -r "/(=== (CONT|RUN|PAUSE).*)|(--- FAIL:.*)|(\\"Test\\":\\".*\/[pP]arallel\\")/d"' > FLAKY_TEST_RUNNER_COMMAND.sh && chmod 777 FLAKY_TEST_RUNNER_COMMAND.sh
 
         mkdir -p ${BRANCH_DIR}/${GITHUB_SHA}/api
         mkdir -p ${BRANCH_DIR}/${GITHUB_SHA}/cli
         mkdir -p ${BRANCH_DIR}/${GITHUB_SHA}/flaky_cli
+        mkdir -p ${BRANCH_DIR}/${GITHUB_SHA}/tokenomics
         mkdir -p ${BRANCH_DIR}/latest/api
         mkdir -p ${BRANCH_DIR}/latest/cli
         mkdir -p ${BRANCH_DIR}/latest/flaky_cli
+        mkdir -p ${BRANCH_DIR}/latest/tokenomics
 
         cd tests/cli_tests
         (./zwallet version --configDir ./config --config ./zbox_config.yaml --wallet ../ignore --silent | grep -A2 'Version info' | sed "s/Version info:/ZWallet Version Info:/") || true
@@ -226,7 +253,7 @@ runs:
 
     - name: "Run API System Tests"
       shell: 'script --return --quiet --command "bash {0}"'
-      if:  ${{ env.RUN_SUBSET_OF_TESTS == 'false' }}
+      if:  ${{ env.RUN_API_SYSTEM_TESTS && env.RUN_SUBSET_OF_TESTS == 'false' }}
       run: |
         echo
         echo "======================================================"
@@ -256,7 +283,7 @@ runs:
         exit $api_system_tests_exit_code
 
     - name: "Archive API Test Config & Console Output"
-      if: ${{ env.RUN_SUBSET_OF_TESTS == 'false' }}
+      if: ${{ always() && env.RUN_API_SYSTEM_TESTS && env.RUN_SUBSET_OF_TESTS == 'false' }}
       uses: actions/upload-artifact@v3
       with:
         name: API-System-Test-${{ env.TEST_TIME }}
@@ -372,6 +399,46 @@ runs:
           ./tests/cli_tests/config
           ./tests/cli_tests/cmdlog.log
           ./${{ env.BRANCH_DIR }}/latest/cli/index.html
+
+    - name: "Run Tokenomics System Tests"
+      shell: 'script --return --quiet --command "bash {0}"'
+      if:  ${{ env.RUN_TOKENOMICS_SYSTEM_TESTS && env.RUN_SUBSET_OF_TESTS == 'false' }}
+      run: |
+        echo
+        echo "======================================================"
+        echo "RUNNING TOKENOMICS SYSTEM TESTS:"
+        echo "======================================================"
+        echo
+        
+        export GOPATH="/root/actions-runner${RUNNER_NAME:(-1)}/_work/_tool/go"
+        export GOMODCACHE="/root/actions-runner${RUNNER_NAME:(-1)}/_work/_tool/go/pkg/mod"
+        export GOCACHE="/root/actions-runner${RUNNER_NAME:(-1)}/_work/_tool/.cache/go-build"
+        export HOME="/root"
+
+        cd tests/tokenomics_tests
+        tokenomics_system_tests_exit_code=0
+        ~/go/bin/gotestsum --jsonfile test-output.json --hide-summary=output --format testname ${{ env.SHOULD_RETRY_FAILURES }} --raw-command -- ../../TOKENOMICS_TEST_RUNNER_COMMAND.sh || tokenomics_system_tests_exit_code=$?
+        cat test-output.json | ~/go/bin/go-test-report --groupSize 1 --output ../../${{ env.BRANCH_DIR }}/${GITHUB_SHA}/tokenomics/index.html --title "0Chain Tokenomics System test suite [${{ env.BRANCH_DIR }}/${GITHUB_SHA:0:8}] ran against [${{ env.NETWORK_URL }}] at [${{ env.TEST_TIME }}]"
+
+        cp -R ../../${{ env.BRANCH_DIR }}/${GITHUB_SHA}/tokenomics ../../${{ env.BRANCH_DIR }}/latest/
+        if [[ $tokenomics_system_tests_exit_code == 0 ]];
+          then
+            echo TOKENOMICS_TESTS_PASSED=true >> $GITHUB_ENV
+          else
+            echo TOKENOMICS_TESTS_PASSED=false >> $GITHUB_ENV
+            echo "::error title=Tokenomics System tests faled!::Tokenomics System tests failed. Ensure tests are running against the correct images/branches and rule out any possible code issues before attempting a re-run"
+        fi
+
+        exit $tokenomics_system_tests_exit_code
+
+    - name: "Archive Tokenomics Test Config & Console Output"
+      if: ${{ always() && env.RUN_TOKENOMICS_SYSTEM_TESTS && env.RUN_SUBSET_OF_TESTS == 'false' }}
+      uses: actions/upload-artifact@v3
+      with:
+        name: Tokenomics-System-Test-${{ env.TEST_TIME }}
+        path: |
+          ./tests/tokenomics_tests/config
+          ./${{ env.BRANCH_DIR }}/latest/tokenomics/index.html
 
     - name: "System Stability Check"
       if: ${{ always() && env.TESTS_RAN == 'true' }}

--- a/run-system-tests/action.yml
+++ b/run-system-tests/action.yml
@@ -253,7 +253,7 @@ runs:
 
     - name: "Run API System Tests"
       shell: 'script --return --quiet --command "bash {0}"'
-      if:  ${{ env.RUN_API_SYSTEM_TESTS && env.RUN_SUBSET_OF_TESTS == 'false' }}
+      if:  ${{ env.RUN_API_SYSTEM_TESTS == "true" && env.RUN_SUBSET_OF_TESTS == 'false' }}
       run: |
         echo
         echo "======================================================"
@@ -283,7 +283,7 @@ runs:
         exit $api_system_tests_exit_code
 
     - name: "Archive API Test Config & Console Output"
-      if: ${{ always() && env.RUN_API_SYSTEM_TESTS && env.RUN_SUBSET_OF_TESTS == 'false' }}
+      if: ${{ always() && env.RUN_API_SYSTEM_TESTS == "true" && env.RUN_SUBSET_OF_TESTS == 'false' }}
       uses: actions/upload-artifact@v3
       with:
         name: API-System-Test-${{ env.TEST_TIME }}
@@ -402,7 +402,7 @@ runs:
 
     - name: "Run Tokenomics System Tests"
       shell: 'script --return --quiet --command "bash {0}"'
-      if:  ${{ env.RUN_TOKENOMICS_SYSTEM_TESTS && env.RUN_SUBSET_OF_TESTS == 'false' }}
+      if:  ${{ env.RUN_TOKENOMICS_SYSTEM_TESTS == "true" && env.RUN_SUBSET_OF_TESTS == 'false' }}
       run: |
         echo
         echo "======================================================"
@@ -432,7 +432,7 @@ runs:
         exit $tokenomics_system_tests_exit_code
 
     - name: "Archive Tokenomics Test Config & Console Output"
-      if: ${{ always() && env.RUN_TOKENOMICS_SYSTEM_TESTS && env.RUN_SUBSET_OF_TESTS == 'false' }}
+      if: ${{ always() && env.RUN_TOKENOMICS_SYSTEM_TESTS == "true" && env.RUN_SUBSET_OF_TESTS == 'false' }}
       uses: actions/upload-artifact@v3
       with:
         name: Tokenomics-System-Test-${{ env.TEST_TIME }}

--- a/run-system-tests/action.yml
+++ b/run-system-tests/action.yml
@@ -253,7 +253,7 @@ runs:
 
     - name: "Run API System Tests"
       shell: 'script --return --quiet --command "bash {0}"'
-      if:  ${{ env.RUN_API_SYSTEM_TESTS == "true" && env.RUN_SUBSET_OF_TESTS == 'false' }}
+      if:  ${{ env.RUN_API_SYSTEM_TESTS == 'true' && env.RUN_SUBSET_OF_TESTS == 'false' }}
       run: |
         echo
         echo "======================================================"
@@ -283,7 +283,7 @@ runs:
         exit $api_system_tests_exit_code
 
     - name: "Archive API Test Config & Console Output"
-      if: ${{ always() && env.RUN_API_SYSTEM_TESTS == "true" && env.RUN_SUBSET_OF_TESTS == 'false' }}
+      if: ${{ always() && env.RUN_API_SYSTEM_TESTS == 'true' && env.RUN_SUBSET_OF_TESTS == 'false' }}
       uses: actions/upload-artifact@v3
       with:
         name: API-System-Test-${{ env.TEST_TIME }}
@@ -402,7 +402,7 @@ runs:
 
     - name: "Run Tokenomics System Tests"
       shell: 'script --return --quiet --command "bash {0}"'
-      if:  ${{ env.RUN_TOKENOMICS_SYSTEM_TESTS == "true" && env.RUN_SUBSET_OF_TESTS == 'false' }}
+      if:  ${{ env.RUN_TOKENOMICS_SYSTEM_TESTS == 'true' && env.RUN_SUBSET_OF_TESTS == 'false' }}
       run: |
         echo
         echo "======================================================"
@@ -432,7 +432,7 @@ runs:
         exit $tokenomics_system_tests_exit_code
 
     - name: "Archive Tokenomics Test Config & Console Output"
-      if: ${{ always() && env.RUN_TOKENOMICS_SYSTEM_TESTS == "true" && env.RUN_SUBSET_OF_TESTS == 'false' }}
+      if: ${{ always() && env.RUN_TOKENOMICS_SYSTEM_TESTS == 'true' && env.RUN_SUBSET_OF_TESTS == 'false' }}
       uses: actions/upload-artifact@v3
       with:
         name: Tokenomics-System-Test-${{ env.TEST_TIME }}


### PR DESCRIPTION
Adds new test suite - tokenomics tests for long-running, non-user-facing tests such as block/blobber rewards and token movement.
Next PR will migrate existing tests from CLI and API suites to this long running suite.
We can then run these on staging only or on demand/nighty basis
Hopefully this will speed up dev feedback 

System tests PR:
https://github.com/0chain/system_test/pull/602
<img width="503" alt="image" src="https://user-images.githubusercontent.com/18306778/227668486-0d14c046-f7ea-4206-85c1-acddcda456c4.png">
