### PR TITLE
Feature/actions bug fix

### DIFF
--- a/deploy-0chain/action.yml
+++ b/deploy-0chain/action.yml
@@ -104,11 +104,12 @@ runs:
       run: |
         branchList="$(cd ../../_actions/0chain/actions/ && find . -name .github | grep -o -P '(?<=./).*(?=/.github)')"
         branchesCount=$(echo -n $branchList | xargs | grep -o ' ' | wc -l)
+        branchesCount=$((branchesCount + 1))
         
-        if [ "$branchesCount" -gt "1" ]; then
+        if [ "$branchesCount" -gt "2" ]; then
           actionsBranch="master"
           echo -e "[$branchesCount] actions branches found in workflow file: \n $branchList \nUsing [master] branch to check out files for deploy. If this is not correct, then remove the ambiguity by changing every occurrence of '0chain/actions' actions to match the intended branch"
-        elif [ "$branchesCount" -gt "0" ]; then
+        elif [ "$branchesCount" -gt "1" ]; then
           for branch in $branchList
           do
             if [ "$branch" != "master" ]; then

--- a/deploy-0chain/action.yml
+++ b/deploy-0chain/action.yml
@@ -102,6 +102,9 @@ runs:
     - name: "Setup Config"
       shell: 'script --return --quiet --command "bash {0}"'
       run: |
+        echo "======== BEFORE REPO SNAPSHOTS BRANCH ========"
+        echo "$(cd ../../_actions/0chain/actions/ && find . -name .github | grep -o -P '(?<=./).*(?=/.github)')"
+        echo "======== AFTER REPO SNAPSHOTS BRANCH ========"
         echo "ACTIONS_BRANCH=$(cd ../../_actions/0chain/actions/ && find . -name .github | grep -o -P '(?<=./).*(?=/.github)')" >> $GITHUB_ENV
         echo "NETWORK_URL=$(echo dev-${RUNNER_NAME:(-1)}.devnet-0chain.net)" >> $GITHUB_ENV
         

--- a/deploy-0chain/action.yml
+++ b/deploy-0chain/action.yml
@@ -102,10 +102,21 @@ runs:
     - name: "Setup Config"
       shell: 'script --return --quiet --command "bash {0}"'
       run: |
-        echo "======== BEFORE REPO SNAPSHOTS BRANCH ========"
-        echo "$(cd ../../_actions/0chain/actions/ && find . -name .github | grep -o -P '(?<=./).*(?=/.github)')"
-        echo "======== AFTER REPO SNAPSHOTS BRANCH ========"
-        echo "ACTIONS_BRANCH=$(cd ../../_actions/0chain/actions/ && find . -name .github | grep -o -P '(?<=./).*(?=/.github)')" >> $GITHUB_ENV
+        branchList="$(cd ../../_actions/0chain/actions/ && find . -name .github | grep -o -P '(?<=./).*(?=/.github)')"
+        branchesCount=$(echo $branchList | grep -c '^')
+        
+        if [ "$branchesCount" -gt "2" ]; then
+          actionsBranch="master"
+          echo "More than two actions branch found in workflow file: [$branchList]. Using [master] branch to check out files for deploy. If this is not correct, then remove the ambiguity by changing every occurrence of '0chain/actions' actions to match the intended branch"
+        elif [ "$branchesCount" -gt "1" ]; then
+          actionsBranch=$(echo $branchList | grep -v master")
+          echo "More than one actions branch found in workflow file: [$branchList]. Using [$actionsBranch] branch to check out files for deploy. If this is not correct, then remove the ambiguity by changing every occurrence of '0chain/actions/*@$actionsBranch' to match the intended branch"
+        else
+          actionsBranch=$branchList
+          echo "Single actions branch [$actionsBranch] found in workflow file."
+        fi
+        
+        echo "ACTIONS_BRANCH=$actionsBranch" >> $GITHUB_ENV
         echo "NETWORK_URL=$(echo dev-${RUNNER_NAME:(-1)}.devnet-0chain.net)" >> $GITHUB_ENV
         
         echo '#!/bin/bash

--- a/deploy-0chain/action.yml
+++ b/deploy-0chain/action.yml
@@ -103,7 +103,7 @@ runs:
       shell: 'script --return --quiet --command "bash {0}"'
       run: |
         branchList="$(cd ../../_actions/0chain/actions/ && find . -name .github | grep -o -P '(?<=./).*(?=/.github)')"
-        branchesCount=$(echo $branchList | grep -c '^')
+        branchesCount=$(echo -n $branchList | grep -c '^')
         
         if [ "$branchesCount" -gt "2" ]; then
           actionsBranch="master"

--- a/deploy-0chain/action.yml
+++ b/deploy-0chain/action.yml
@@ -109,7 +109,7 @@ runs:
           actionsBranch="master"
           echo "More than two actions branch found in workflow file: [$branchList]. Using [master] branch to check out files for deploy. If this is not correct, then remove the ambiguity by changing every occurrence of '0chain/actions' actions to match the intended branch"
         elif [ "$branchesCount" -gt "1" ]; then
-          actionsBranch=$(echo $branchList | grep -v master")
+          actionsBranch=$(echo $branchList | grep -v master)
           echo "More than one actions branch found in workflow file: [$branchList]. Using [$actionsBranch] branch to check out files for deploy. If this is not correct, then remove the ambiguity by changing every occurrence of '0chain/actions/*@$actionsBranch' to match the intended branch"
         else
           actionsBranch=$branchList

--- a/deploy-0chain/action.yml
+++ b/deploy-0chain/action.yml
@@ -104,6 +104,7 @@ runs:
       run: |
         branchList="$(cd ../../_actions/0chain/actions/ && find . -name .github | grep -o -P '(?<=./).*(?=/.github)')"
         branchesCount=$(echo -n $branchList | wc -l | xargs)
+        echo "count is [$branchesCount]"
         
         if [ "$branchesCount" -gt "2" ]; then
           actionsBranch="master"

--- a/deploy-0chain/action.yml
+++ b/deploy-0chain/action.yml
@@ -107,7 +107,7 @@ runs:
         
         if [ "$branchesCount" -gt "1" ]; then
           actionsBranch="master"
-          echo "[$branchesCount] actions branches found in workflow file: \n[$branchList]. Using [master] branch to check out files for deploy. If this is not correct, then remove the ambiguity by changing every occurrence of '0chain/actions' actions to match the intended branch"
+          echo -e "[$branchesCount] actions branches found in workflow file: \n $branchList \nUsing [master] branch to check out files for deploy. If this is not correct, then remove the ambiguity by changing every occurrence of '0chain/actions' actions to match the intended branch"
         elif [ "$branchesCount" -gt "0" ]; then
           for branch in $branchList
           do
@@ -115,7 +115,7 @@ runs:
               actionsBranch=$branch
             fi
           done
-          echo "[$branchesCount] actions branches found in workflow file: \n[$branchList]. Using [$actionsBranch] branch to check out files for deploy. If this is not correct, then remove the ambiguity by changing every occurrence of '0chain/actions/*@$actionsBranch' to match the intended branch"
+          echo -e "[$branchesCount] actions branches found in workflow file: \n $branchList \nUsing [$actionsBranch] branch to check out files for deploy. If this is not correct, then remove the ambiguity by changing every occurrence of '0chain/actions/*@$actionsBranch' to match the intended branch"
         else
           actionsBranch=$branchList
           echo "Single actions branch [$actionsBranch] found in workflow file."

--- a/deploy-0chain/action.yml
+++ b/deploy-0chain/action.yml
@@ -104,14 +104,18 @@ runs:
       run: |
         branchList="$(cd ../../_actions/0chain/actions/ && find . -name .github | grep -o -P '(?<=./).*(?=/.github)')"
         branchesCount=$(echo -n $branchList | xargs | grep -o ' ' | wc -l)
-        echo "count is [$branchesCount]"
         
         if [ "$branchesCount" -gt "1" ]; then
           actionsBranch="master"
-          echo "More than two actions branch found in workflow file: [$branchList]. Using [master] branch to check out files for deploy. If this is not correct, then remove the ambiguity by changing every occurrence of '0chain/actions' actions to match the intended branch"
+          echo "[$branchesCount] actions branches found in workflow file: \n[$branchList]. Using [master] branch to check out files for deploy. If this is not correct, then remove the ambiguity by changing every occurrence of '0chain/actions' actions to match the intended branch"
         elif [ "$branchesCount" -gt "0" ]; then
-          actionsBranch=$(echo $branchList | grep -v master)
-          echo "More than one actions branch found in workflow file: [$branchList]. Using [$actionsBranch] branch to check out files for deploy. If this is not correct, then remove the ambiguity by changing every occurrence of '0chain/actions/*@$actionsBranch' to match the intended branch"
+          for branch in $branchList
+          do
+            if [ "$branch" != "master" ]; then
+              actionsBranch=$branch
+            fi
+          done
+          echo "[$branchesCount] actions branches found in workflow file: \n[$branchList]. Using [$actionsBranch] branch to check out files for deploy. If this is not correct, then remove the ambiguity by changing every occurrence of '0chain/actions/*@$actionsBranch' to match the intended branch"
         else
           actionsBranch=$branchList
           echo "Single actions branch [$actionsBranch] found in workflow file."

--- a/deploy-0chain/action.yml
+++ b/deploy-0chain/action.yml
@@ -103,7 +103,7 @@ runs:
       shell: 'script --return --quiet --command "bash {0}"'
       run: |
         branchList="$(cd ../../_actions/0chain/actions/ && find . -name .github | grep -o -P '(?<=./).*(?=/.github)')"
-        branchesCount=$(echo -n $branchList | wc -l | xargs)
+        branchesCount=$(echo -n $branchList | xargs | grep -o ' ' | wc -l)
         echo "count is [$branchesCount]"
         
         if [ "$branchesCount" -gt "2" ]; then

--- a/deploy-0chain/action.yml
+++ b/deploy-0chain/action.yml
@@ -103,7 +103,7 @@ runs:
       shell: 'script --return --quiet --command "bash {0}"'
       run: |
         branchList="$(cd ../../_actions/0chain/actions/ && find . -name .github | grep -o -P '(?<=./).*(?=/.github)')"
-        branchesCount=$(echo -n $branchList | grep -c '^')
+        branchesCount=$(echo -n $branchList | wc -l | xargs)
         
         if [ "$branchesCount" -gt "2" ]; then
           actionsBranch="master"

--- a/deploy-0chain/action.yml
+++ b/deploy-0chain/action.yml
@@ -106,10 +106,10 @@ runs:
         branchesCount=$(echo -n $branchList | xargs | grep -o ' ' | wc -l)
         echo "count is [$branchesCount]"
         
-        if [ "$branchesCount" -gt "2" ]; then
+        if [ "$branchesCount" -gt "1" ]; then
           actionsBranch="master"
           echo "More than two actions branch found in workflow file: [$branchList]. Using [master] branch to check out files for deploy. If this is not correct, then remove the ambiguity by changing every occurrence of '0chain/actions' actions to match the intended branch"
-        elif [ "$branchesCount" -gt "1" ]; then
+        elif [ "$branchesCount" -gt "0" ]; then
           actionsBranch=$(echo $branchList | grep -v master)
           echo "More than one actions branch found in workflow file: [$branchList]. Using [$actionsBranch] branch to check out files for deploy. If this is not correct, then remove the ambiguity by changing every occurrence of '0chain/actions/*@$actionsBranch' to match the intended branch"
         else


### PR DESCRIPTION
Existing logic:
If 1 branch is found, that branch is used (current logic)
If > 1 branch is found, the action falls over 

New logic:
Old logic for single branch remains.

If > 1 branches are found, the non master branch is used:
<img width="1162" alt="image" src="https://github.com/0chain/actions/assets/18306778/aa3e9924-7028-46cf-bff9-4a743e46bf4e">

If > 2 branches are found, then master is used:
