### PR TITLE
Feature/upgrade gosdk in system tests

### DIFF
--- a/deploy-0chain/action.yml
+++ b/deploy-0chain/action.yml
@@ -481,16 +481,16 @@ runs:
         GOSDK_HEAD=$(curl -s -H "Authorization: token ${{ inputs.svc_account_secret }}" https://api.github.com/repos/0chain/gosdk/git/refs/heads/${{ env.GOSDK_VERSION }} | jq -r '.object.sha')
 
         echo '#!/bin/bash
-        cd $2
-        echo "Upgrading [$3] to GOSDK [${{ env.GOSDK_VERSION }}/$1]"
+        echo "Upgrading [$2] to GOSDK [${{ env.GOSDK_VERSION }}/$1]"
         go get github.com/0chain/gosdk@$1 || { echo "::error title=Failed to retrieve gosdk::failed to retrieve gosdk [${{ env.GOSDK_VERSION }}]" && exit 1; }
-        go mod tidy || { echo "::error title=Failed to upgrade $3 gosdk::failed to upgrade $3 gosdk to [${{ env.GOSDK_VERSION }}]" && exit 1; }
-        cd -
+        go mod tidy || { echo "::error title=Failed to upgrade $2 gosdk::failed to upgrade $2 gosdk to [${{ env.GOSDK_VERSION }}]" && exit 1; }
         ' > ./upgrade-gosdk.sh;
         chmod 777 ./upgrade-gosdk.sh
 
-        ./upgrade-gosdk.sh $GOSDK_HEAD ./zwalletcli  zwalletcli
-        ./upgrade-gosdk.sh $GOSDK_HEAD ../zboxcli    zboxcli
+        cd ./zwalletcli
+        ./upgrade-gosdk.sh $GOSDK_HEAD zwalletcli
+        cd ../zboxcli
+        ./upgrade-gosdk.sh $GOSDK_HEAD zboxcli
 
 
     - name: "Build CLI Binaries"

--- a/deploy-0chain/action.yml
+++ b/deploy-0chain/action.yml
@@ -470,7 +470,7 @@ runs:
 
     - name: "Upgrade GoSDK"
       shell: 'script --return --quiet --command "bash {0}"'
-      if: ${{ env.GOSDK_VERSION != '' && env.GOSDK_VERSION == 'NONE' }}
+      if: ${{ env.GOSDK_VERSION != '' && env.GOSDK_VERSION != 'NONE' }}
       run: |
         echo
         echo "=============================================================="

--- a/deploy-0chain/action.yml
+++ b/deploy-0chain/action.yml
@@ -468,6 +468,31 @@ runs:
         fetch-depth: 1
         path: ./zboxcli
 
+    - name: "Upgrade GoSDK"
+      shell: 'script --return --quiet --command "bash {0}"'
+      if: ${{ env.GOSDK_VERSION != '' && env.GOSDK_VERSION == 'NONE' }}
+      run: |
+        echo
+        echo "=============================================================="
+        echo "UPGRADING GOSDK IN ZBOXCLI, ZWALLETCLI"
+        echo "=============================================================="
+        echo
+
+        GOSDK_HEAD=$(curl -s -H "Authorization: token ${{ inputs.svc_account_secret }}" https://api.github.com/repos/0chain/gosdk/git/refs/heads/${{ env.GOSDK_VERSION }} | jq -r '.object.sha')
+
+        echo '#!/bin/bash
+        cd $2
+        echo "Upgrading [$3] to GOSDK [${{ env.GOSDK_VERSION }}/$1]"
+        go get github.com/0chain/gosdk@$GOSDK_HEAD || { echo "::error title=Failed to retrieve gosdk::failed to retrieve gosdk [${{ env.GOSDK_VERSION }}]" && exit 1; }
+        go mod tidy || { echo "::error title=Failed to upgrade $3 gosdk::failed to upgrade $3 gosdk to [${{ env.GOSDK_VERSION }}]" && exit 1; }
+        cd -
+        ' > ./upgrade-gosdk.sh;
+        chmod 777 ./upgrade-gosdk.sh
+
+        ./upgrade-gosdk.sh $GOSDK_HEAD ./zwalletcli  zwalletcli
+        ./upgrade-gosdk.sh $GOSDK_HEAD ../zboxcli    zboxcli
+
+
     - name: "Build CLI Binaries"
       shell: 'script --return --quiet --command "bash {0}"'
       run: |
@@ -478,24 +503,11 @@ runs:
         echo
         echo "Building zwalletcli [${{ env.ZWALLET_BRANCH }}]..."
         cd zwalletcli
-
-
-        if [[ -n "${{ env.GOSDK_VERSION }}" && "${{ env.GOSDK_VERSION }}" != "NONE" ]];
-        then
-          echo "Upgrading zwalletcli to GOSDK [${{ env.GOSDK_VERSION }}]"
-          GOPROXY=direct go get github.com/0chain/gosdk@${{ env.GOSDK_VERSION }} || { echo "::error title=Failed to retrieve gosdk::failed to retrieve gosdk [${{ env.GOSDK_VERSION }}]" && exit 1; }
-          go mod tidy || { echo "::error title=Failed to upgrade gosdk on zwallet CLI::failed to upgrade zwallet CLI gosdk to [${{ env.GOSDK_VERSION }}]" && exit 1; }
-        fi
         make install > build.log 2>&1 || { cat build.log && echo "::error title=zwallet CLI build failed::zwallet CLI build failed" && exit 1; }
         mv zwallet ..
+        
         echo "Building zboxcli [${{ env.ZBOX_BRANCH }}]..."
         cd ../zboxcli
-        if [[ -n "${{ env.GOSDK_VERSION }}" && "${{ env.GOSDK_VERSION }}" != "NONE" ]];
-        then
-          echo "Upgrading zboxcli to GOSDK [${{ env.GOSDK_VERSION }}]"
-          GOPROXY=direct go get github.com/0chain/gosdk@${{ env.GOSDK_VERSION }} || { echo "::error title=Failed to retrieve gosdk::failed to retrieve gosdk [${{ env.GOSDK_VERSION }}]" && exit 1; }
-          go mod tidy || { echo "::error title=Failed to upgrade gosdk on zbox CLI::failed to upgrade zbox CLI gosdk to [${{ env.GOSDK_VERSION }}]" && exit 1; }
-        fi
         make install > build.log 2>&1 || { cat build.log && echo "::error title=zbox CLI build failed::zbox CLI build failed" && exit 1; }
         mv zbox ..
         echo "CLI build SUCCESS!"

--- a/deploy-0chain/action.yml
+++ b/deploy-0chain/action.yml
@@ -488,9 +488,9 @@ runs:
         chmod 777 ./upgrade-gosdk.sh
 
         cd ./zwalletcli
-        ./upgrade-gosdk.sh $GOSDK_HEAD zwalletcli
+        ../upgrade-gosdk.sh $GOSDK_HEAD zwalletcli
         cd ../zboxcli
-        ./upgrade-gosdk.sh $GOSDK_HEAD zboxcli
+        ../upgrade-gosdk.sh $GOSDK_HEAD zboxcli
 
 
     - name: "Build CLI Binaries"

--- a/deploy-0chain/action.yml
+++ b/deploy-0chain/action.yml
@@ -483,7 +483,7 @@ runs:
         if [[ -n "${{ env.GOSDK_VERSION }}" && "${{ env.GOSDK_VERSION }}" != "NONE" ]];
         then
           echo "Upgrading zwalletcli to GOSDK [${{ env.GOSDK_VERSION }}]"
-          go get github.com/0chain/gosdk@${{ env.GOSDK_VERSION }} || { echo "::error title=Failed to retrieve gosdk::failed to retrieve gosdk [${{ env.GOSDK_VERSION }}]" && exit 1; }
+          GOPROXY=direct go get github.com/0chain/gosdk@${{ env.GOSDK_VERSION }} || { echo "::error title=Failed to retrieve gosdk::failed to retrieve gosdk [${{ env.GOSDK_VERSION }}]" && exit 1; }
           go mod tidy || { echo "::error title=Failed to upgrade gosdk on zwallet CLI::failed to upgrade zwallet CLI gosdk to [${{ env.GOSDK_VERSION }}]" && exit 1; }
         fi
         make install > build.log 2>&1 || { cat build.log && echo "::error title=zwallet CLI build failed::zwallet CLI build failed" && exit 1; }
@@ -493,7 +493,7 @@ runs:
         if [[ -n "${{ env.GOSDK_VERSION }}" && "${{ env.GOSDK_VERSION }}" != "NONE" ]];
         then
           echo "Upgrading zboxcli to GOSDK [${{ env.GOSDK_VERSION }}]"
-          go get github.com/0chain/gosdk@${{ env.GOSDK_VERSION }} || { echo "::error title=Failed to retrieve gosdk::failed to retrieve gosdk [${{ env.GOSDK_VERSION }}]" && exit 1; }
+          GOPROXY=direct go get github.com/0chain/gosdk@${{ env.GOSDK_VERSION }} || { echo "::error title=Failed to retrieve gosdk::failed to retrieve gosdk [${{ env.GOSDK_VERSION }}]" && exit 1; }
           go mod tidy || { echo "::error title=Failed to upgrade gosdk on zbox CLI::failed to upgrade zbox CLI gosdk to [${{ env.GOSDK_VERSION }}]" && exit 1; }
         fi
         make install > build.log 2>&1 || { cat build.log && echo "::error title=zbox CLI build failed::zbox CLI build failed" && exit 1; }

--- a/deploy-0chain/action.yml
+++ b/deploy-0chain/action.yml
@@ -126,7 +126,7 @@ runs:
         echo "NETWORK_URL=$(echo dev-${RUNNER_NAME:(-1)}.devnet-0chain.net)" >> $GITHUB_ENV
         
         echo '#!/bin/bash
-        if [[ -z "$1" ]];then
+        if [[ -z "$1" || "$1" == "NONE" ]];then
             if [[ -z "$2" ]];then
               echo "::error title=Branch/Image not specified!::$3 was not specified explicitly and could not be resolved using repo_snapshots_branch"
               echo "BRANCH_NOT_SPECIFIED_FAILURE=true" >> $GITHUB_ENV
@@ -141,18 +141,19 @@ runs:
         ' > ./check-params.sh;
         chmod 777 check-params.sh
         
-        ./check-params.sh "${{inputs.miner_image}}"        "${{ env.SNAPSHOT_BRANCH_MINER_TAG }}"        "MINER_TAG"
-        ./check-params.sh "${{inputs.sharder_image}}"      "${{ env.SNAPSHOT_BRANCH_SHARDER_TAG }}"      "SHARDER_TAG"
-        ./check-params.sh "${{inputs.blobber_image}}"      "${{ env.SNAPSHOT_BRANCH_BLOBBER_TAG }}"      "BLOBBER_TAG"
-        ./check-params.sh "${{inputs.validator_image}}"    "${{ env.SNAPSHOT_BRANCH_VALIDATOR_TAG }}"    "VALIDATOR_TAG"
-        ./check-params.sh "${{inputs.authorizer_image}}"   "${{ env.SNAPSHOT_BRANCH_AUTHORIZER_TAG }}"   "AUTHORIZER_TAG"
-        ./check-params.sh "${{inputs.zbox_image}}"         "${{ env.SNAPSHOT_BRANCH_ZBOX_TAG }}"         "ZBOX_TAG"
-        ./check-params.sh "${{inputs.zdns_image}}"         "${{ env.SNAPSHOT_BRANCH_ZDNS_TAG }}"         "ZDNS_TAG"
-        ./check-params.sh "${{inputs.zbox_cli_branch}}"    "${{ env.SNAPSHOT_BRANCH_ZBOXCLI }}"          "ZBOX_BRANCH"
-        ./check-params.sh "${{inputs.zwallet_cli_branch}}" "${{ env.SNAPSHOT_BRANCH_ZWALLETCLI }}"       "ZWALLET_BRANCH"
-        ./check-params.sh "${{inputs.zs3_minio}}"          "${{ env.SNAPSHOT_BRANCH_MIBIOSERVER_TAG }}"  "ZS3_MINIO"
-        ./check-params.sh "${{inputs.zs3_logsearchapi}}"   "${{ env.SNAPSHOT_BRANCH_LOGSEARCHAPI_TAG }}" "ZS3_LOGSEARCHAPI"
-        ./check-params.sh "${{inputs.zs3_client}}"         "${{ env.SNAPSHOT_BRANCH_CLIENTAPI_TAG }}"    "ZS3_CLIENT"
+        ./check-params.sh "${{inputs.miner_image}}"            "${{ env.SNAPSHOT_BRANCH_MINER_TAG }}"        "MINER_TAG"
+        ./check-params.sh "${{inputs.sharder_image}}"          "${{ env.SNAPSHOT_BRANCH_SHARDER_TAG }}"      "SHARDER_TAG"
+        ./check-params.sh "${{inputs.blobber_image}}"          "${{ env.SNAPSHOT_BRANCH_BLOBBER_TAG }}"      "BLOBBER_TAG"
+        ./check-params.sh "${{inputs.validator_image}}"        "${{ env.SNAPSHOT_BRANCH_VALIDATOR_TAG }}"    "VALIDATOR_TAG"
+        ./check-params.sh "${{inputs.authorizer_image}}"       "${{ env.SNAPSHOT_BRANCH_AUTHORIZER_TAG }}"   "AUTHORIZER_TAG"
+        ./check-params.sh "${{inputs.zbox_image}}"             "${{ env.SNAPSHOT_BRANCH_ZBOX_TAG }}"         "ZBOX_TAG"
+        ./check-params.sh "${{inputs.zdns_image}}"             "${{ env.SNAPSHOT_BRANCH_ZDNS_TAG }}"         "ZDNS_TAG"
+        ./check-params.sh "${{inputs.zbox_cli_branch}}"        "${{ env.SNAPSHOT_BRANCH_ZBOXCLI }}"          "ZBOX_BRANCH"
+        ./check-params.sh "${{inputs.zwallet_cli_branch}}"     "${{ env.SNAPSHOT_BRANCH_ZWALLETCLI }}"       "ZWALLET_BRANCH"
+        ./check-params.sh "${{inputs.zs3_minio}}"              "${{ env.SNAPSHOT_BRANCH_MIBIOSERVER_TAG }}"  "ZS3_MINIO"
+        ./check-params.sh "${{inputs.zs3_logsearchapi}}"       "${{ env.SNAPSHOT_BRANCH_LOGSEARCHAPI_TAG }}" "ZS3_LOGSEARCHAPI"
+        ./check-params.sh "${{inputs.zs3_client}}"             "${{ env.SNAPSHOT_BRANCH_CLIENTAPI_TAG }}"    "ZS3_CLIENT"
+        ./check-params.sh "${{inputs.custom_go_sdk_version}}"  "${{ env.SNAPSHOT_BRANCH_GOSDK }}"            "GOSDK_VERSION"
         
         ALWAYS_TEARDOWN=true
         echo "TEARDOWN_CONDITION=${{inputs.teardown_condition}}" >> $GITHUB_ENV
@@ -479,21 +480,21 @@ runs:
         cd zwalletcli
 
 
-        if [[ -n "${{ inputs.custom_go_sdk_version }}" && "${{ inputs.custom_go_sdk_version }}" != "NONE" ]];
+        if [[ -n "${{ env.GOSDK_VERSION }}" && "${{ env.GOSDK_VERSION }}" != "NONE" ]];
         then
-          echo "Upgrading zwalletcli to GOSDK [${{ inputs.custom_go_sdk_version }}]"
-          go get github.com/0chain/gosdk@${{ inputs.custom_go_sdk_version }} || { echo "::error title=Failed to retrieve gosdk::failed to retrieve gosdk [${{ inputs.custom_go_sdk_version }}]" && exit 1; }
-          go mod tidy || { echo "::error title=Failed to upgrade gosdk on zwallet CLI::failed to upgrade zwallet CLI gosdk to [${{ inputs.custom_go_sdk_version }}]" && exit 1; }
+          echo "Upgrading zwalletcli to GOSDK [${{ env.GOSDK_VERSION }}]"
+          go get github.com/0chain/gosdk@${{ env.GOSDK_VERSION }} || { echo "::error title=Failed to retrieve gosdk::failed to retrieve gosdk [${{ env.GOSDK_VERSION }}]" && exit 1; }
+          go mod tidy || { echo "::error title=Failed to upgrade gosdk on zwallet CLI::failed to upgrade zwallet CLI gosdk to [${{ env.GOSDK_VERSION }}]" && exit 1; }
         fi
         make install > build.log 2>&1 || { cat build.log && echo "::error title=zwallet CLI build failed::zwallet CLI build failed" && exit 1; }
         mv zwallet ..
         echo "Building zboxcli [${{ env.ZBOX_BRANCH }}]..."
         cd ../zboxcli
-        if [[ -n "${{ inputs.custom_go_sdk_version }}" && "${{ inputs.custom_go_sdk_version }}" != "NONE" ]];
+        if [[ -n "${{ env.GOSDK_VERSION }}" && "${{ env.GOSDK_VERSION }}" != "NONE" ]];
         then
-          echo "Upgrading zboxcli to GOSDK [${{ inputs.custom_go_sdk_version }}]"
-          go get github.com/0chain/gosdk@${{ inputs.custom_go_sdk_version }} || { echo "::error title=Failed to retrieve gosdk::failed to retrieve gosdk [${{ inputs.custom_go_sdk_version }}]" && exit 1; }
-          go mod tidy || { echo "::error title=Failed to upgrade gosdk on zbox CLI::failed to upgrade zbox CLI gosdk to [${{ inputs.custom_go_sdk_version }}]" && exit 1; }
+          echo "Upgrading zboxcli to GOSDK [${{ env.GOSDK_VERSION }}]"
+          go get github.com/0chain/gosdk@${{ env.GOSDK_VERSION }} || { echo "::error title=Failed to retrieve gosdk::failed to retrieve gosdk [${{ env.GOSDK_VERSION }}]" && exit 1; }
+          go mod tidy || { echo "::error title=Failed to upgrade gosdk on zbox CLI::failed to upgrade zbox CLI gosdk to [${{ env.GOSDK_VERSION }}]" && exit 1; }
         fi
         make install > build.log 2>&1 || { cat build.log && echo "::error title=zbox CLI build failed::zbox CLI build failed" && exit 1; }
         mv zbox ..

--- a/deploy-0chain/action.yml
+++ b/deploy-0chain/action.yml
@@ -481,7 +481,7 @@ runs:
         GOSDK_HEAD=$(curl -s -H "Authorization: token ${{ inputs.svc_account_secret }}" https://api.github.com/repos/0chain/gosdk/git/refs/heads/${{ env.GOSDK_VERSION }} | jq -r '.object.sha')
 
         echo '#!/bin/bash
-        echo "Upgrading [$2] to GOSDK [${{ env.GOSDK_VERSION }}/$1]"
+        echo "Upgrading [$2] to GOSDK [${{ env.GOSDK_VERSION }}($1)]"
         go get github.com/0chain/gosdk@$1 || { echo "::error title=Failed to retrieve gosdk::failed to retrieve gosdk [${{ env.GOSDK_VERSION }}]" && exit 1; }
         go mod tidy || { echo "::error title=Failed to upgrade $2 gosdk::failed to upgrade $2 gosdk to [${{ env.GOSDK_VERSION }}]" && exit 1; }
         ' > ./upgrade-gosdk.sh;

--- a/deploy-0chain/action.yml
+++ b/deploy-0chain/action.yml
@@ -483,7 +483,7 @@ runs:
         echo '#!/bin/bash
         cd $2
         echo "Upgrading [$3] to GOSDK [${{ env.GOSDK_VERSION }}/$1]"
-        go get github.com/0chain/gosdk@$GOSDK_HEAD || { echo "::error title=Failed to retrieve gosdk::failed to retrieve gosdk [${{ env.GOSDK_VERSION }}]" && exit 1; }
+        go get github.com/0chain/gosdk@$1 || { echo "::error title=Failed to retrieve gosdk::failed to retrieve gosdk [${{ env.GOSDK_VERSION }}]" && exit 1; }
         go mod tidy || { echo "::error title=Failed to upgrade $3 gosdk::failed to upgrade $3 gosdk to [${{ env.GOSDK_VERSION }}]" && exit 1; }
         cd -
         ' > ./upgrade-gosdk.sh;

--- a/resolve-repo-snapshot/action.yaml
+++ b/resolve-repo-snapshot/action.yaml
@@ -63,8 +63,7 @@ runs:
       if: ${{ env.SKIP_TESTS != 'true' }}
       run: |
         cd ./repo-snapshots
-        echo "Resolved branches.json on repo-snapshots branch [${{ env.REPO_SNAPSHOTS_BRANCH }}]:"
-        cat branches.json
+        echo "Resolved branches.json on repo-snapshots branch [${{ env.REPO_SNAPSHOTS_BRANCH }}]"
         while IFS= read -r output; do     echo "$output" >> $GITHUB_ENV; done < <(jq -r 'to_entries[] | select(.value.defaultBranch != null) | "SNAPSHOT_BRANCH_\(.key | ascii_upcase)=\(.value.defaultBranch)"' "branches.json")
         while IFS= read -r output; do     echo "$output" >> $GITHUB_ENV; done < <(jq -r 'to_entries[] | select(.value.sprintBranch != null) | "SNAPSHOT_BRANCH_\(.key | ascii_upcase)=\(.value.sprintBranch)"' "branches.json")
 

--- a/run-system-tests/action.yml
+++ b/run-system-tests/action.yml
@@ -253,18 +253,18 @@ runs:
         path: ./s3-migration
         token: "${{ inputs.svc_account_secret }}"
 
-    - name: "Setup Go"
-      shell: 'script --return --quiet --command "bash {0}"'
-      run: |
-        [ -f ./https://go.dev/dl/go1.20.3.linux-amd64.tar.gz ] || wget https://go.dev/dl/go1.20.3.linux-amd64.tar.gz
-        [ -d /usr/local/go ] &&  rm -rf /usr/local/go
-        [ -f /usr/local/bin/go ] &&  rm -rf /usr/local/bin/go
-        tar -C /usr/local -xzf ./go1.20.3.linux-amd64.tar.gz
+    # - name: "Setup Go"
+    #   shell: 'script --return --quiet --command "bash {0}"'
+    #   run: |
+    #     [ -f ./https://go.dev/dl/go1.20.3.linux-amd64.tar.gz ] || wget https://go.dev/dl/go1.20.3.linux-amd64.tar.gz
+    #     [ -d /usr/local/go ] &&  rm -rf /usr/local/go
+    #     [ -f /usr/local/bin/go ] &&  rm -rf /usr/local/bin/go
+    #     tar -C /usr/local -xzf ./go1.20.3.linux-amd64.tar.gz
         
-        echo "PATH=$PATH:/usr/local/go/bin" >> $GITHUB_ENV
-        export PATH=$PATH:/usr/local/go/bin
-        which go
-        go env
+    #     echo "PATH=$PATH:/usr/local/go/bin" >> $GITHUB_ENV
+    #     export PATH=$PATH:/usr/local/go/bin
+    #     which go
+    #     go env
 
     - name: "Install dependencies"
       shell: 'script --return --quiet --command "bash {0}"'

--- a/run-system-tests/action.yml
+++ b/run-system-tests/action.yml
@@ -295,19 +295,22 @@ runs:
         GOSDK_HEAD=$(curl -s -H "Authorization: token ${{ inputs.svc_account_secret }}" https://api.github.com/repos/0chain/gosdk/git/refs/heads/${{ env.GOSDK_VERSION }} | jq -r '.object.sha')
         
         echo '#!/bin/bash
-        cd $2
-        echo "Upgrading [$3] to GOSDK [${{ env.GOSDK_VERSION }}/$1]"
+        echo "Upgrading [$2] to GOSDK [${{ env.GOSDK_VERSION }}/$1]"
         go get github.com/0chain/gosdk@$1 || { echo "::error title=Failed to retrieve gosdk::failed to retrieve gosdk [${{ env.GOSDK_VERSION }}]" && exit 1; }
-        go mod tidy || { echo "::error title=Failed to upgrade $3 gosdk::failed to upgrade $3 gosdk to [${{ env.GOSDK_VERSION }}]" && exit 1; }
-        cd -
+        go mod tidy || { echo "::error title=Failed to upgrade $2 gosdk::failed to upgrade $2 gosdk to [${{ env.GOSDK_VERSION }}]" && exit 1; }
         ' > ./upgrade-gosdk.sh;
         chmod 777 ./upgrade-gosdk.sh
         
-        ./upgrade-gosdk.sh $GOSDK_HEAD ./zwalletcli       zwalletcli
-        ./upgrade-gosdk.sh $GOSDK_HEAD ../zboxcli         zboxcli
-        ./upgrade-gosdk.sh $GOSDK_HEAD ../s3-migration    zs3cli
-        ./upgrade-gosdk.sh $GOSDK_HEAD ../tests/cli_tests "CLI System Tests"
-        ./upgrade-gosdk.sh $GOSDK_HEAD ../tests/api_tests "API System Tests"
+        cd ./zwalletcli 
+        ./upgrade-gosdk.sh $GOSDK_HEAD zwalletcli
+        cd ../zboxcli
+        ./upgrade-gosdk.sh $GOSDK_HEAD zboxcli
+        cd ../s3-migration 
+        ./upgrade-gosdk.sh $GOSDK_HEAD zs3cli
+        cd ../tests/cli_tests
+        ./upgrade-gosdk.sh $GOSDK_HEAD "CLI System Tests"
+        cd ../api_tests
+        ./upgrade-gosdk.sh $GOSDK_HEAD "API System Tests"
         
 
     - name: "Build CLI Binaries"

--- a/run-system-tests/action.yml
+++ b/run-system-tests/action.yml
@@ -110,7 +110,7 @@ runs:
       run: |
         echo "RUNNER_NUMBER=${RUNNER_NAME:(-1)}" >> $GITHUB_ENV
         echo '#!/bin/bash
-        if [[ -z "$1" ]];then
+        if [[ -z "$1" || "$1" == "NONE" ]];then
            if [[ -z "$2" ]];then
              echo "::error title=Branch/Image not specified!::$3 was not specified explicitly and could not be resolved using repo_snapshots_branch"
              exit 1
@@ -131,7 +131,7 @@ runs:
         ./check-params.sh "${{inputs.zwallet_cli_branch}}"      "${{ env.SNAPSHOT_BRANCH_ZWALLETCLI }}"   "ZWALLET_BRANCH"
         ./check-params.sh "${{inputs.system_tests_branch}}"     "${{ env.SNAPSHOT_BRANCH_SYSTEM_TEST }}"  "SYSTEM_TESTS_BRANCH"
         ./check-params.sh "${{inputs.s3_migration_cli_branch}}" "${{ env.SNAPSHOT_BRANCH_S3-MIGRATION }}" "S3_MIGRATION_BRANCH"
-        ./check-params.sh "${{inputs.custom_go_sdk_version}}"   "${{ env.SNAPSHOT_BRANCH_GOSDK }}" "GOSDK_VERSION"
+        ./check-params.sh "${{inputs.custom_go_sdk_version}}"   "${{ env.SNAPSHOT_BRANCH_GOSDK }}"        "GOSDK_VERSION"
         
         echo "NETWORK_URL=$(echo ${{ inputs.network }})" >> $GITHUB_ENV
         echo "GOMODCACHE=/root/actions-runner${RUNNER_NAME:(-1)}/_work/_tool/go/pkg/mod" >> $GITHUB_ENV

--- a/run-system-tests/action.yml
+++ b/run-system-tests/action.yml
@@ -108,7 +108,7 @@ runs:
     - name: "Config: Run tests against 0Chain network"
       shell: 'script --return --quiet --command "bash {0}"'
       run: |
-        
+        echo "RUNNER_NUMBER=${RUNNER_NAME:(-1)}" >> $GITHUB_ENV
         echo '#!/bin/bash
         if [[ -z "$1" ]];then
            if [[ -z "$2" ]];then
@@ -365,6 +365,8 @@ runs:
         sed "s,ethereum_node_url:.*,ethereum_node_url: 'https://rpc.tenderly.co/fork/${{ inputs.TENDERLY_FORK_ID }}'," -i ./tests/cli_tests/config/zbox_config.yaml
         sed "s,ethereum_node_url:.*,ethereum_node_url: 'https://rpc.tenderly.co/fork/${{ inputs.TENDERLY_FORK_ID }}'," -i ./tests/api_tests/config/api_tests_config.yaml
         sed "s,0box_url:.*,0box_url: https://0box.${{ env.NETWORK_URL }}," -i ./tests/api_tests/config/api_tests_config.yaml
+        sed "s,s3_bucket_name:.*,s3_bucket_name: system-tests-s3-migration-small-${{ env.RUNNER_NUMBER }}," -i ./tests/cli_tests/config/cli_tests_config.yaml
+        sed "s,s3_bucket_name_alternate:.*,s3_bucket_name_alternate: alternate-test-bucket-${{ env.RUNNER_NUMBER }}," -i ./tests/cli_tests/config/cli_tests_config.yaml
         sed "s,s3_access_key:.*,s3_access_key: ${{ inputs.S3_ACCESS_KEY }}," -i ./tests/cli_tests/config/cli_tests_config.yaml
         sed "s,s3_secret_key:.*,s3_secret_key: ${{ inputs.S3_SECRET_KEY }}," -i ./tests/cli_tests/config/cli_tests_config.yaml
         

--- a/run-system-tests/action.yml
+++ b/run-system-tests/action.yml
@@ -295,7 +295,7 @@ runs:
         echo '#!/bin/bash
         cd $1
         echo "Upgrading [$2] to GOSDK [${{ env.GOSDK_VERSION }}]"
-        go get github.com/0chain/gosdk@${{ env.GOSDK_VERSION }} || { echo "::error title=Failed to retrieve gosdk::failed to retrieve gosdk [${{ env.GOSDK_VERSION }}]" && exit 1; }
+        GOPROXY=direct go get github.com/0chain/gosdk@${{ env.GOSDK_VERSION }} || { echo "::error title=Failed to retrieve gosdk::failed to retrieve gosdk [${{ env.GOSDK_VERSION }}]" && exit 1; }
         go mod tidy || { echo "::error title=Failed to upgrade $1 gosdk::failed to upgrade $2 gosdk to [${{ env.GOSDK_VERSION }}]" && exit 1; }
         cd -
         ' > ./upgrade-gosdk.sh;

--- a/run-system-tests/action.yml
+++ b/run-system-tests/action.yml
@@ -253,19 +253,6 @@ runs:
         path: ./s3-migration
         token: "${{ inputs.svc_account_secret }}"
 
-    # - name: "Setup Go"
-    #   shell: 'script --return --quiet --command "bash {0}"'
-    #   run: |
-    #     [ -f ./https://go.dev/dl/go1.20.3.linux-amd64.tar.gz ] || wget https://go.dev/dl/go1.20.3.linux-amd64.tar.gz
-    #     [ -d /usr/local/go ] &&  rm -rf /usr/local/go
-    #     [ -f /usr/local/bin/go ] &&  rm -rf /usr/local/bin/go
-    #     tar -C /usr/local -xzf ./go1.20.3.linux-amd64.tar.gz
-        
-    #     echo "PATH=$PATH:/usr/local/go/bin" >> $GITHUB_ENV
-    #     export PATH=$PATH:/usr/local/go/bin
-    #     which go
-    #     go env
-
     - name: "Install dependencies"
       shell: 'script --return --quiet --command "bash {0}"'
       run: |
@@ -292,6 +279,32 @@ runs:
         echo "4> installing cypress dependencies..."
         apt install -y yarn libgtk2.0-0 libgtk-3-0 libgbm-dev libnotify-dev libgconf-2-4 libnss3 libxss1 libasound2 libxtst6 xauth xvfb
 
+    - name: "Upgrade GoSDK"
+      shell: 'script --return --quiet --command "bash {0}"'
+      if: ${{ inputs.custom_go_sdk_version != '' && inputs.custom_go_sdk_version == 'NONE' }}
+      run: |
+        echo
+        echo "=============================================================="
+        echo "UPGRADING GOSDK IN ZBOXCLI, ZWALLETCLI, ZS3CLI & SYSTEM TESTS"
+        echo "=============================================================="
+        echo
+        
+        echo '#!/bin/bash
+        cd $1
+        echo "Upgrading [$2] to GOSDK [${{ inputs.custom_go_sdk_version }}]"
+        go get github.com/0chain/gosdk@${{ inputs.custom_go_sdk_version }} || { echo "::error title=Failed to retrieve gosdk::failed to retrieve gosdk [${{ inputs.custom_go_sdk_version }}]" && exit 1; }
+        go mod tidy || { echo "::error title=Failed to upgrade $1 gosdk::failed to upgrade $2 gosdk to [${{ inputs.custom_go_sdk_version }}]" && exit 1; }
+        cd -
+        ' > ./upgrade-gosdk.sh;
+        chmod 777 ./upgrade-gosdk.sh
+        
+        ./upgrade-gosdk.sh ./zwalletcli zwalletcli
+        ./upgrade-gosdk.sh ../zboxcli zboxcli
+        ./upgrade-gosdk.sh ../s3-migration zs3cli
+        ./upgrade-gosdk.sh ../tests/cli_tests "CLI System Tests"
+        ./upgrade-gosdk.sh ../tests/api_tests "API System Tests"
+        
+
     - name: "Build CLI Binaries"
       shell: 'script --return --quiet --command "bash {0}"'
       run: |
@@ -305,35 +318,16 @@ runs:
         
         echo "Building zwalletcli [${{ env.ZWALLET_BRANCH }}]..."
         cd zwalletcli
-  
-        if [[ -n "${{ inputs.custom_go_sdk_version }}" && "${{ inputs.custom_go_sdk_version }}" != "NONE" ]];
-        then
-          echo "Upgrading zwalletcli to GOSDK [${{ inputs.custom_go_sdk_version }}]"
-          go get github.com/0chain/gosdk@${{ inputs.custom_go_sdk_version }} || { echo "::error title=Failed to retrieve gosdk::failed to retrieve gosdk [${{ inputs.custom_go_sdk_version }}]" && exit 1; }
-          go mod tidy || { echo "::error title=Failed to upgrade gosdk on zwallet CLI::failed to upgrade zwallet CLI gosdk to [${{ inputs.custom_go_sdk_version }}]" && exit 1; }
-        fi
         make install > build.log 2>&1 || { cat build.log && echo "::error title=zwallet CLI build failed::zwallet CLI build failed" && exit 1; }
         mv zwallet ../tests/cli_tests
         
         echo "Building zboxcli [${{ env.ZBOX_BRANCH }}]..."
         cd ../zboxcli
-        if [[ -n "${{ inputs.custom_go_sdk_version }}" && "${{ inputs.custom_go_sdk_version }}" != "NONE" ]];
-        then
-          echo "Upgrading zboxcli to GOSDK [${{ inputs.custom_go_sdk_version }}]"
-          go get github.com/0chain/gosdk@${{ inputs.custom_go_sdk_version }} || { echo "::error title=Failed to retrieve gosdk::failed to retrieve gosdk [${{ inputs.custom_go_sdk_version }}]" && exit 1; }
-          go mod tidy || { echo "::error title=Failed to upgrade gosdk on zbox CLI::failed to upgrade zbox CLI gosdk to [${{ inputs.custom_go_sdk_version }}]" && exit 1; }
-        fi
         make install > build.log 2>&1 || { cat build.log && echo "::error title=zbox CLI build failed::zbox CLI build failed" && exit 1; }
         mv zbox ../tests/cli_tests
         
         echo "Building s3 migration CLI [${{ env.S3_MIGRATION_BRANCH }}]..."
         cd ../s3-migration
-        if [[ -n "${{ inputs.custom_go_sdk_version }}" && "${{ inputs.custom_go_sdk_version }}" != "NONE" ]];
-        then
-          echo "Upgrading zboxcli to GOSDK [${{ inputs.custom_go_sdk_version }}]"
-          go get github.com/0chain/gosdk@${{ inputs.custom_go_sdk_version }} || { echo "::error title=Failed to retrieve gosdk::failed to retrieve gosdk [${{ inputs.custom_go_sdk_version }}]" && exit 1; }
-          go mod tidy -compat=1.17 || { echo "::error title=Failed to upgrade gosdk on zbox CLI::failed to upgrade zbox CLI gosdk to [${{ inputs.custom_go_sdk_version }}]" && exit 1; }
-        fi
         make build > build.log 2>&1 || { cat build.log && echo "::error title=s3 migration CLI build failed::s3 migration CLI build failed" && exit 1; }
         mv s3mgrt ../tests/cli_tests
         

--- a/run-system-tests/action.yml
+++ b/run-system-tests/action.yml
@@ -292,20 +292,22 @@ runs:
         echo "=============================================================="
         echo
         
+        GOSDK_HEAD=$(curl -s -H "Authorization: token ${{ inputs.svc_account_secret }}" https://api.github.com/repos/0chain/gosdk/git/refs/heads/${{ env.GOSDK_VERSION }} | jq -r '.object.sha')
+        
         echo '#!/bin/bash
-        cd $1
-        echo "Upgrading [$2] to GOSDK [${{ env.GOSDK_VERSION }}]"
-        GOPROXY=direct go get github.com/0chain/gosdk@${{ env.GOSDK_VERSION }} || { echo "::error title=Failed to retrieve gosdk::failed to retrieve gosdk [${{ env.GOSDK_VERSION }}]" && exit 1; }
-        go mod tidy || { echo "::error title=Failed to upgrade $1 gosdk::failed to upgrade $2 gosdk to [${{ env.GOSDK_VERSION }}]" && exit 1; }
+        cd $2
+        echo "Upgrading [$3] to GOSDK [${{ env.GOSDK_VERSION }}/$1]"
+        go get github.com/0chain/gosdk@$GOSDK_HEAD || { echo "::error title=Failed to retrieve gosdk::failed to retrieve gosdk [${{ env.GOSDK_VERSION }}]" && exit 1; }
+        go mod tidy || { echo "::error title=Failed to upgrade $3 gosdk::failed to upgrade $3 gosdk to [${{ env.GOSDK_VERSION }}]" && exit 1; }
         cd -
         ' > ./upgrade-gosdk.sh;
         chmod 777 ./upgrade-gosdk.sh
         
-        ./upgrade-gosdk.sh ./zwalletcli zwalletcli
-        ./upgrade-gosdk.sh ../zboxcli zboxcli
-        ./upgrade-gosdk.sh ../s3-migration zs3cli
-        ./upgrade-gosdk.sh ../tests/cli_tests "CLI System Tests"
-        ./upgrade-gosdk.sh ../tests/api_tests "API System Tests"
+        ./upgrade-gosdk.sh $GOSDK_HEAD ./zwalletcli       zwalletcli
+        ./upgrade-gosdk.sh $GOSDK_HEAD ../zboxcli         zboxcli
+        ./upgrade-gosdk.sh $GOSDK_HEAD ../s3-migration    zs3cli
+        ./upgrade-gosdk.sh $GOSDK_HEAD ../tests/cli_tests "CLI System Tests"
+        ./upgrade-gosdk.sh $GOSDK_HEAD ../tests/api_tests "API System Tests"
         
 
     - name: "Build CLI Binaries"

--- a/run-system-tests/action.yml
+++ b/run-system-tests/action.yml
@@ -302,15 +302,15 @@ runs:
         chmod 777 ./upgrade-gosdk.sh
         
         cd ./zwalletcli 
-        ./upgrade-gosdk.sh $GOSDK_HEAD zwalletcli
+        ../upgrade-gosdk.sh $GOSDK_HEAD zwalletcli
         cd ../zboxcli
-        ./upgrade-gosdk.sh $GOSDK_HEAD zboxcli
+        ../upgrade-gosdk.sh $GOSDK_HEAD zboxcli
         cd ../s3-migration 
-        ./upgrade-gosdk.sh $GOSDK_HEAD zs3cli
+        ../upgrade-gosdk.sh $GOSDK_HEAD zs3cli
         cd ../tests/cli_tests
-        ./upgrade-gosdk.sh $GOSDK_HEAD "CLI System Tests"
+        ../../upgrade-gosdk.sh $GOSDK_HEAD "CLI System Tests"
         cd ../api_tests
-        ./upgrade-gosdk.sh $GOSDK_HEAD "API System Tests"
+        ../../upgrade-gosdk.sh $GOSDK_HEAD "API System Tests"
         
 
     - name: "Build CLI Binaries"

--- a/run-system-tests/action.yml
+++ b/run-system-tests/action.yml
@@ -297,7 +297,7 @@ runs:
         echo '#!/bin/bash
         cd $2
         echo "Upgrading [$3] to GOSDK [${{ env.GOSDK_VERSION }}/$1]"
-        go get github.com/0chain/gosdk@$GOSDK_HEAD || { echo "::error title=Failed to retrieve gosdk::failed to retrieve gosdk [${{ env.GOSDK_VERSION }}]" && exit 1; }
+        go get github.com/0chain/gosdk@$1 || { echo "::error title=Failed to retrieve gosdk::failed to retrieve gosdk [${{ env.GOSDK_VERSION }}]" && exit 1; }
         go mod tidy || { echo "::error title=Failed to upgrade $3 gosdk::failed to upgrade $3 gosdk to [${{ env.GOSDK_VERSION }}]" && exit 1; }
         cd -
         ' > ./upgrade-gosdk.sh;

--- a/run-system-tests/action.yml
+++ b/run-system-tests/action.yml
@@ -284,7 +284,7 @@ runs:
 
     - name: "Upgrade GoSDK"
       shell: 'script --return --quiet --command "bash {0}"'
-      if: ${{ env.GOSDK_VERSION != '' && env.GOSDK_VERSION == 'NONE' }}
+      if: ${{ env.GOSDK_VERSION != '' && env.GOSDK_VERSION != 'NONE' }}
       run: |
         echo
         echo "=============================================================="

--- a/run-system-tests/action.yml
+++ b/run-system-tests/action.yml
@@ -295,7 +295,7 @@ runs:
         GOSDK_HEAD=$(curl -s -H "Authorization: token ${{ inputs.svc_account_secret }}" https://api.github.com/repos/0chain/gosdk/git/refs/heads/${{ env.GOSDK_VERSION }} | jq -r '.object.sha')
         
         echo '#!/bin/bash
-        echo "Upgrading [$2] to GOSDK [${{ env.GOSDK_VERSION }}/$1]"
+        echo "Upgrading [$2] to GOSDK [${{ env.GOSDK_VERSION }}($1)]"
         go get github.com/0chain/gosdk@$1 || { echo "::error title=Failed to retrieve gosdk::failed to retrieve gosdk [${{ env.GOSDK_VERSION }}]" && exit 1; }
         go mod tidy || { echo "::error title=Failed to upgrade $2 gosdk::failed to upgrade $2 gosdk to [${{ env.GOSDK_VERSION }}]" && exit 1; }
         ' > ./upgrade-gosdk.sh;

--- a/run-system-tests/action.yml
+++ b/run-system-tests/action.yml
@@ -116,10 +116,12 @@ runs:
              exit 1
            else
              echo "Using $3 [$2] from repo_snapshots_branch"
+             export $3=$2
              echo "$3=$2" >> $GITHUB_ENV
            fi
         else
            echo "Using $3 tag [$1] from repo_snapshots_branch"
+           export $3=$1
            echo "$3=$1" >> $GITHUB_ENV
         fi
         ' > ./check-params.sh;
@@ -129,6 +131,7 @@ runs:
         ./check-params.sh "${{inputs.zwallet_cli_branch}}"      "${{ env.SNAPSHOT_BRANCH_ZWALLETCLI }}"   "ZWALLET_BRANCH"
         ./check-params.sh "${{inputs.system_tests_branch}}"     "${{ env.SNAPSHOT_BRANCH_SYSTEM_TEST }}"  "SYSTEM_TESTS_BRANCH"
         ./check-params.sh "${{inputs.s3_migration_cli_branch}}" "${{ env.SNAPSHOT_BRANCH_S3-MIGRATION }}" "S3_MIGRATION_BRANCH"
+        ./check-params.sh "${{inputs.custom_go_sdk_version}}"   "${{ env.SNAPSHOT_BRANCH_GOSDK }}" "GOSDK_VERSION"
         
         echo "NETWORK_URL=$(echo ${{ inputs.network }})" >> $GITHUB_ENV
         echo "GOMODCACHE=/root/actions-runner${RUNNER_NAME:(-1)}/_work/_tool/go/pkg/mod" >> $GITHUB_ENV
@@ -143,7 +146,7 @@ runs:
             echo RUN_SMOKE_TESTS=false >> $GITHUB_ENV
         fi
         
-        if [[ "${{ inputs.run_frontend_tests }}" == "true"  || ("${{ inputs.custom_go_sdk_version }}" != "" && "${{ inputs.custom_go_sdk_version }}" != "NONE") ]];
+        if [[ "${{ inputs.run_frontend_tests }}" == "true"  || ("$GOSDK_VERSION" != "" && "$GOSDK_VERSION" != "NONE") ]];
           then
             echo RUN_FRONTEND_TESTS=false >> $GITHUB_ENV
           else
@@ -214,7 +217,7 @@ runs:
         echo "0wallet CLI branch:       [${{ env.ZWALLET_BRANCH }}]"
         echo "s3 migration CLI branch:  [${{ env.S3_MIGRATION_BRANCH }}]"
         echo "Ethereum node URL:        [https://rpc.tenderly.co/fork/${{ inputs.TENDERLY_FORK_ID }}]"
-        echo "Custom gosdk version:     [${{ inputs.custom_go_sdk_version }}]"
+        echo "Custom gosdk version:     [${{ env.GOSDK_VERSION }}]"
         echo "Test file filter:         [${{ inputs.test_file_filter }}]"
         echo "Running CLI tests:        [${{ env.RUN_CLI_SYSTEM_TESTS }}]"
         echo "Running API tests:        [${{ env.RUN_API_SYSTEM_TESTS }}]"
@@ -281,7 +284,7 @@ runs:
 
     - name: "Upgrade GoSDK"
       shell: 'script --return --quiet --command "bash {0}"'
-      if: ${{ inputs.custom_go_sdk_version != '' && inputs.custom_go_sdk_version == 'NONE' }}
+      if: ${{ env.GOSDK_VERSION != '' && env.GOSDK_VERSION == 'NONE' }}
       run: |
         echo
         echo "=============================================================="
@@ -291,9 +294,9 @@ runs:
         
         echo '#!/bin/bash
         cd $1
-        echo "Upgrading [$2] to GOSDK [${{ inputs.custom_go_sdk_version }}]"
-        go get github.com/0chain/gosdk@${{ inputs.custom_go_sdk_version }} || { echo "::error title=Failed to retrieve gosdk::failed to retrieve gosdk [${{ inputs.custom_go_sdk_version }}]" && exit 1; }
-        go mod tidy || { echo "::error title=Failed to upgrade $1 gosdk::failed to upgrade $2 gosdk to [${{ inputs.custom_go_sdk_version }}]" && exit 1; }
+        echo "Upgrading [$2] to GOSDK [${{ env.GOSDK_VERSION }}]"
+        go get github.com/0chain/gosdk@${{ env.GOSDK_VERSION }} || { echo "::error title=Failed to retrieve gosdk::failed to retrieve gosdk [${{ env.GOSDK_VERSION }}]" && exit 1; }
+        go mod tidy || { echo "::error title=Failed to upgrade $1 gosdk::failed to upgrade $2 gosdk to [${{ env.GOSDK_VERSION }}]" && exit 1; }
         cd -
         ' > ./upgrade-gosdk.sh;
         chmod 777 ./upgrade-gosdk.sh
@@ -403,9 +406,9 @@ runs:
         git clone -q https://github.com/0chain/gosdk.git
         cd gosdk
 
-        if [[ -n "${{  inputs.custom_go_sdk_version }}" && "${{  inputs.custom_go_sdk_version }}" != "NONE" ]];
+        if [[ -n "${{  env.GOSDK_VERSION }}" && "${{  env.GOSDK_VERSION }}" != "NONE" ]];
         then
-          git checkout ${{  inputs.custom_go_sdk_version }}
+          git checkout ${{  env.GOSDK_VERSION }}
         fi
 
         cd ..


### PR DESCRIPTION
Use repo snapshots to upgrade gosdk, ensuring staging tests always run against latest staging gosdk, and devs can override branches quickly using repo snapshots 
see run https://github.com/0chain/system_test/actions/runs/5920048468/job/16051161022